### PR TITLE
Updated links

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,36 +4,33 @@ sleep 5
 echo "And it begins!"
 
 sudo apt-get update
-wget http://www.cmake.org/files/v3.3/cmake-3.3.0-rc2.tar.gz
-tar zxf cmake-3.3.0-rc2.tar.gz
-cd cmake-3.3.0-rc2/
+wget https://cmake.org/files/v3.4/cmake-3.4.0-rc1.tar.gz
+tar zxf cmake-3.4.0-rc1.tar.gz
+cd cmake-3.4.0-rc1/
 sudo ./bootstrap
 sudo make
 sudo make install
 cd ..
 
 sudo apt-get -y install libopus-dev libexpat1-dev libssl-dev libasound2-dev libudev-dev libavahi-client-dev libcurl4-openssl-dev libjs-jquery
-wget https://github.com/the-raspberry-pi-guy/game_stream/raw/master/Dependencies/libevdev-dev_1.4.3%2Bdfsg-1_armhf.deb
-wget https://github.com/the-raspberry-pi-guy/game_stream/raw/master/Dependencies/libevdev-tools_1.4.3%2Bdfsg-1_armhf.deb
-wget https://github.com/the-raspberry-pi-guy/game_stream/raw/master/Dependencies/libevdev2_1.4.3%2Bdfsg-1_armhf.deb
+wget http://archive.raspbian.org/raspbian/pool/main/libe/libevdev/libevdev-dev_1.4.4%2bdfsg-1_armhf.deb
+wget http://archive.raspbian.org/raspbian/pool/main/libe/libevdev/libevdev-tools_1.4.4%2bdfsg-1_armhf.deb
+wget http://archive.raspbian.org/raspbian/pool/main/libe/libevdev/libevdev2_1.4.4%2bdfsg-1_armhf.deb
 sudo dpkg -i libevdev*
 cd
 
-git clone https://github.com/the-raspberry-pi-guy/game_stream
+mkdir game_stream
 cd game_stream
-sudo rm -r Dependencies
-cd Moonlight
-tar xf moonlight-embedded-2.0.2.tar.xz -C /home/pi/game_stream/
-cd ..
-sudo rm -r Moonlight
-cd moonlight-embedded-2.0.2/
+wget https://github.com/irtimmer/moonlight-embedded/releases/download/v2.1.1/moonlight-embedded-2.1.1.tar.xz
+tar xf moonlight-embedded-2.1.1.tar.xz -C /home/pi/game_stream/
+cd moonlight-embedded-2.1.1/
 mkdir build
 cd build/
 sudo cmake ../
 sudo make
 sudo make install
 cd ~
-sudo rm cmake-3.3.0-rc2.tar.gz libevdev2_1.4.3+dfsg-1_armhf.deb libevdev-dev_1.4.3+dfsg-1_armhf.deb libevdev-tools_1.4.3+dfsg-1_armhf.deb
+sudo rm cmake-3.4.0-rc1.tar.gz libevdev2_1.4.4+dfsg-1_armhf.deb libevdev-tools_1.4.4+dfsg-1_armhf.deb libevdev-dev_1.4.4+dfsg-1_armhf.deb
 cd game_stream
 
 echo "*Tentative* And... We should be all done now!"


### PR DESCRIPTION
Updated links to newer versions, had to make some changes though. Couldn't figure out how to upload the new libevdev .debs into Dependencies, so I put the direct download instead, and made a small change to the script so it doesn't stray away from your video guide.

Also, sorry if this isn't the correct way to do something like this in GitHub, new to this site
